### PR TITLE
Fix: OPN(A) FM-Synth Envelope / Preparation: OPNA Hardware LFO

### DIFF
--- a/np2/cbus/board86.c
+++ b/np2/cbus/board86.c
@@ -27,18 +27,20 @@ static void IOOUTCALL opna_o18a(UINT port, REG8 dat) {
 	}
 	S98_put(NORMAL2608, addr, dat);
 	if (addr < 0x10) {
+		//0x00-0x0F: SSG
 		if (addr != 0x0e) {
 			psggen_setreg(&psg1, addr, dat);
 		}
 	}
 	else {
-		if (addr < 0x20) {
-			if (opn.extend) {
-				rhythm_setreg(&rhythm, addr, dat);
-			}
-		}
-		else if ((addr < 0x30) && (addr > 0x22)) {
-			if (addr == 0x28) {
+		if ((addr < 0x30) && (addr != 0x22)) {
+			if (addr < 0x20) {
+				//0x10-0x1F: Rhythm
+				if (opn.extend) {
+					rhythm_setreg(&rhythm, addr, dat);
+				}
+			} else if (addr == 0x28) {
+				//0x28: Key On/Off
 				if ((dat & 0x0f) < 3) {
 					opngen_keyon(dat & 0x0f, dat);
 				}
@@ -48,13 +50,15 @@ static void IOOUTCALL opna_o18a(UINT port, REG8 dat) {
 				}
 			}
 			else {
+				//0x24-0x27: Timer
 				fmtimer_setreg(addr, dat);
 				if (addr == 0x27) {
 					opnch[2].extop = dat & 0xc0;
 				}
 			}
 		}
-		else if ((addr < 0xc0) || (addr == 0x22)) {
+		else if (addr < 0xc0) {
+			//0x22, 0x30-0xBF
 			opngen_setreg(0, addr, dat);
 		}
 		opn.reg[addr] = dat;

--- a/np2/cbus/boardspb.c
+++ b/np2/cbus/boardspb.c
@@ -26,16 +26,20 @@ static void IOOUTCALL spb_o18a(UINT port, REG8 dat) {
 	}
 	S98_put(NORMAL2608, addr, dat);
 	if (addr < 0x10) {
+		//0x00-0x0F: SSG
 		if (addr != 0x0e) {
 			psggen_setreg(&psg1, addr, dat);
 		}
 	}
 	else {
-		if (addr < 0x20) {
-			rhythm_setreg(&rhythm, addr, dat);
-		}
-		else if ((addr < 0x30) && (addr > 0x22)) {
-			if (addr == 0x28) {
+		if ((addr < 0x30) && (addr != 0x22)) {
+			if (addr < 0x20) {
+				//0x10-0x1F: Rhythm
+				if (opn.extend) {
+					rhythm_setreg(&rhythm, addr, dat);
+				}
+			} else if (addr == 0x28) {
+				//0x28: Key On/Off
 				if ((dat & 0x0f) < 3) {
 					opngen_keyon(dat & 0x0f, dat);
 				}
@@ -45,13 +49,15 @@ static void IOOUTCALL spb_o18a(UINT port, REG8 dat) {
 				}
 			}
 			else {
+				//0x24-0x27: Timer
 				fmtimer_setreg(addr, dat);
 				if (addr == 0x27) {
 					opnch[2].extop = dat & 0xc0;
 				}
 			}
 		}
-		else if ((addr < 0xc0) || (addr == 0x22)) {
+		else if (addr < 0xc0) {
+			//0x22, 0x30-0xBF
 			opngen_setreg(0, addr, dat);
 		}
 		opn.reg[addr] = dat;
@@ -156,7 +162,7 @@ static void IOOUTCALL spr_o58a(UINT port, REG8 dat) {
 		return;
 	}
 	S98_put(NORMAL2608_2, addr, dat);
-	if (addr < 0x30) {
+	if ((addr < 0x30) && (addr != 0x22)) {
 		if (addr == 0x28) {
 			if ((dat & 0x0f) < 3) {
 				opngen_keyon((dat & 0x0f) + 6, dat);

--- a/np2/cbus/boardx2.c
+++ b/np2/cbus/boardx2.c
@@ -94,18 +94,20 @@ static void IOOUTCALL opna_o18a(UINT port, REG8 dat) {
 	}
 	S98_put(NORMAL2608, addr, dat);
 	if (addr < 0x10) {
+		//0x00-0x0F: SSG
 		if (addr != 0x0e) {
 			psggen_setreg(&psg2, addr, dat);
 		}
 	}
 	else {
-		if (addr < 0x20) {
-			if (opn.extend) {
-				rhythm_setreg(&rhythm, addr, dat);
-			}
-		}
-		else if ((addr < 0x30) && (addr > 0x22)) {
-			if (addr == 0x28) {
+		if ((addr < 0x30) && (addr != 0x22)) {
+			if (addr < 0x20) {
+				//0x10-0x1F: Rhythm
+				if (opn.extend) {
+					rhythm_setreg(&rhythm, addr, dat);
+				}
+			} else if (addr == 0x28) {
+				//0x28: Key On/Off
 				if ((dat & 0x0f) < 3) {
 					opngen_keyon((dat & 0x0f) + 3, dat);
 				}
@@ -115,13 +117,15 @@ static void IOOUTCALL opna_o18a(UINT port, REG8 dat) {
 				}
 			}
 			else {
+				//0x24-0x27: Timer
 				fmtimer_setreg(addr, dat);
 				if (addr == 0x27) {
 					opnch[2].extop = dat & 0xc0;
 				}
 			}
 		}
-		else if ((addr < 0xc0) || (addr == 0x22)) {
+		else if (addr < 0xc0) {
+			//0x22, 0x30-0xBF
 			opngen_setreg(3, addr, dat);
 		}
 		opn.reg[addr] = dat;

--- a/np2/sound/opngen.h
+++ b/np2/sound/opngen.h
@@ -111,6 +111,7 @@ const SINT32	*release;			// release ratio
 	SINT32		env_inc_decay1;		// envelope decay1 step
 	SINT32		env_inc_decay2;		// envelope decay2 step
 	SINT32		env_inc_release;	// envelope release step
+	UINT		amon;				// AMON
 } OPNSLOT;
 
 typedef struct {
@@ -132,6 +133,8 @@ typedef struct {
 	UINT8	extop;				// extendopelator-enable
 	UINT8	stereo;				// stereo-enable
 	UINT8	padding2;
+	UINT32	pms;				//PMS
+	UINT32	ams;				//AMS
 } OPNCH;
 
 typedef struct {
@@ -144,6 +147,9 @@ typedef struct {
 	SINT32	outdc;
 	SINT32	outdr;
 	SINT32	calcremain;
+	SINT32	lfo_freq_cnt;			// frequency count
+	SINT32	lfo_freq_inc;			// frequency step
+	UINT	lfo_enable;
 	UINT8	keyreg[OPNCH_MAX];
 } _OPNGEN, *OPNGEN;
 

--- a/np2/sound/opngen.h
+++ b/np2/sound/opngen.h
@@ -133,8 +133,8 @@ typedef struct {
 	UINT8	extop;				// extendopelator-enable
 	UINT8	stereo;				// stereo-enable
 	UINT8	padding2;
-	UINT32	pms;				//PMS
-	UINT32	ams;				//AMS
+	SINT32	pms;				//PMS
+	SINT32	ams;				//AMS
 } OPNCH;
 
 typedef struct {
@@ -163,6 +163,10 @@ typedef struct {
 
 	SINT32	sintable[SIN_ENT];
 	SINT32	envtable[EVC_ENT];
+#ifdef OPNGENX86
+	char	sinshift[SIN_ENT];
+	char	envshift[EVC_ENT];
+#endif
 	SINT32	envcurve[EVC_ENT*2 + 1];
 } OPNCFG;
 

--- a/np2/sound/opngen86.cpp
+++ b/np2/sound/opngen86.cpp
@@ -1,0 +1,308 @@
+#include	"compiler.h"
+#include	"pccore.h"
+#include	"iocore.h"
+#include	"sound.h"
+#include	"fmboard.h"
+
+extern "C"	OPNCFG	opncfg;
+
+//==============================================================
+//			スロット
+//--------------------------------------------------------------
+//	◆引数
+//		SINT32 envout	エンベロープジェネレータからの入力
+//		SINT32 freq_cnt	現在の位相
+//		SINT32 feedback	フィードバック入力
+//	◆返り値
+//		SINT32			振幅レベル
+//==============================================================
+SINT32 slot_out(SINT32 envout, SINT32 freq_cnt, SINT32 feedback ){
+
+	freq_cnt += feedback;
+	freq_cnt >>= (FREQ_BITS - SIN_BITS);
+	freq_cnt &= (SIN_ENT - 1);
+	
+	return((opncfg.sintable[freq_cnt] * opncfg.envtable[envout]) >> (opncfg.sinshift[freq_cnt] + opncfg.envshift[envout]));
+
+}
+
+//==============================================================
+//			オペレータ
+//--------------------------------------------------------------
+//	◆引数
+//		OPNCH	*ch		
+//		UINT32	lfo_level;		//ハードウェアLFO
+//		UINT8	lfo_shift;		//ハードウェアLFO
+//	◆返り値
+//		無し
+//==============================================================
+static void calcratechannel(OPNCH *ch, SINT32 lfo_level, char lfo_shift) {
+
+	SINT32	i;
+	SINT64	i64;			//計算用
+	UINT	cnt_slot;		//Slot用	カウンタ
+
+	OPNSLOT	*slot;			//各Slot
+
+	SINT32	envout;
+	SINT32	opout;
+
+
+	opngen.feedback2 = 0;
+	opngen.feedback3 = 0;
+	opngen.feedback4 = 0;
+
+	//Each Slot process
+	for (cnt_slot=0; cnt_slot<4; cnt_slot++){
+		slot = &ch->slot[cnt_slot];
+
+		//音程
+		i = slot->freq_inc;
+		i64 = i * lfo_level;
+		i64 *= ch->pms;
+		i += (SINT32)(i64 >> (32 + lfo_shift));		//音程LFO処理
+		slot->freq_cnt += i;
+
+		//Envelope Generator
+		slot->env_cnt += slot->env_inc;
+		if (slot->env_cnt >= slot->env_end){
+			switch(slot->env_mode){
+				case EM_ATTACK:
+					slot->env_mode = EM_DECAY1;
+					slot->env_cnt = EC_DECAY;
+					slot->env_end = slot->decaylevel;
+					slot->env_inc = slot->env_inc_decay1;
+					break;
+				case EM_DECAY1:	
+					slot->env_mode = EM_DECAY2;
+					slot->env_cnt = slot->decaylevel;
+					slot->env_end = EC_OFF;
+					slot->env_inc = slot->env_inc_decay2;
+					break;
+				case EM_RELEASE:
+					slot->env_mode = EM_OFF;
+				case EM_DECAY2:
+					slot->env_cnt = EC_OFF;
+					slot->env_end = EC_OFF + 1;
+					slot->env_inc = 0;
+					ch->playing &= ~(1 << cnt_slot);
+			}
+		}
+		envout = slot->totallevel;
+		if ((slot->amon) & 0x01) {
+			envout += (lfo_level * ch->ams) >> lfo_shift;	//音量LFO
+		}
+		envout -= opncfg.envcurve[slot->env_cnt >> ENV_BITS];
+
+		//Osc
+		if (envout>0) {
+			switch(cnt_slot){
+				case 0:
+					opout = ch->op1fb;
+					if (ch->feedback > 0){
+						i = ch->op1fb >> ch->feedback;
+					} else {
+						i = 0;
+					}
+					ch->op1fb = slot_out(envout, slot->freq_cnt, i);
+					opout += ch->op1fb;
+					opout /= 2;
+					if (ch->algorithm == 5) {
+						opngen.feedback2 = opout;
+						opngen.feedback3 = opout;
+						opngen.feedback4 = opout;
+					} else {
+						*ch->connect1 += opout;
+					}
+					break;
+				case 1:
+					*ch->connect2 += slot_out(envout, slot->freq_cnt, opngen.feedback2);
+					break;
+				case 2:
+					*ch->connect3 += slot_out(envout, slot->freq_cnt, opngen.feedback3);
+					break;
+				case 3:
+					*ch->connect4 += slot_out(envout, slot->freq_cnt, opngen.feedback4);
+					break;
+			}
+		}
+	}
+}
+
+//==============================================================
+//			
+//--------------------------------------------------------------
+//	◆引数
+//		void	*hdl	
+//		SINT32	*pcm	波形バッファ
+//		UINT	count	必要サンプル数
+//	◆返り値
+//		無し
+//==============================================================
+void SOUNDCALL opngen_getpcm(void *hdl, SINT32 *pcm, UINT count) {
+
+	SINT32	i;				//計算用
+	SINT64	i64;			//計算用
+	UINT	cnt_ch;			//Slot用	カウンタ
+
+	OPNCH	*fm = opnch;	//各Ch
+
+	SINT32	samp_l;
+	SINT32	samp_r;
+
+	SINT32	lfo_level;		//ハードウェアLFO
+	char	lfo_shift;		//ハードウェアLFO
+
+	if (!opngen.playing) {
+		return;
+	}
+
+	while(count>0){
+
+		samp_l = opngen.outdl * opngen.calcremain;
+		samp_r = opngen.outdr * opngen.calcremain;
+		opngen.calcremain = FMDIV_ENT - opngen.calcremain;
+
+		while(1){
+			opngen.playing = 0;
+			opngen.outdc = 0;
+			opngen.outdl = 0;
+			opngen.outdr = 0;
+
+			//Hardware LFO Frequency
+			if	(opngen.lfo_enable & 0x01){
+				i = opngen.lfo_freq_cnt + opngen.lfo_freq_inc;
+				opngen.lfo_freq_cnt = i;
+				i >>= (FREQ_BITS - SIN_BITS);
+				i &= (SIN_ENT - 1);
+				lfo_level = opncfg.sintable[i];
+				lfo_shift = opncfg.sinshift[i];
+			} else {
+				lfo_level = 0;
+				lfo_shift = 0;
+			}
+
+			//Each Channel process
+			for (cnt_ch=0; cnt_ch<opngen.playchannels; cnt_ch++) {
+				fm = &opnch[cnt_ch];
+				if (fm->playing & fm->outslot) {
+					calcratechannel(fm, lfo_level, lfo_shift);
+					opngen.playing++;
+				}
+			}
+			opngen.outdl += opngen.outdc;
+			opngen.outdr += opngen.outdc;
+			opngen.outdl >>= FMVOL_SFTBIT;
+			opngen.outdr >>= FMVOL_SFTBIT;
+			if (opngen.calcremain > opncfg.calc1024) {
+				opngen.calcremain -= opncfg.calc1024;
+				samp_l += opngen.outdl * opncfg.calc1024;
+				samp_r += opngen.outdr * opncfg.calc1024;
+			} else {
+				break;
+			}
+		}
+
+		i64 = opngen.calcremain * opngen.outdl + samp_l;
+		i64 *= opncfg.fmvol;
+		pcm[0] += (SINT32)(i64 >> 32);
+
+		i64 = opngen.calcremain * opngen.outdr + samp_r;
+		i64 *= opncfg.fmvol;
+		pcm[1] += (SINT32)(i64 >> 32);
+
+		pcm += 2;
+
+		opngen.calcremain = opncfg.calc1024 - opngen.calcremain;
+		count--;
+	}
+
+}
+
+//==============================================================
+//			
+//--------------------------------------------------------------
+//	◆引数
+//		void	*hdl	
+//		SINT32	*pcm	波形バッファ
+//		UINT	count	必要サンプル数
+//	◆返り値
+//		無し
+//==============================================================
+void SOUNDCALL opngen_getpcmvr(void *hdl, SINT32 *pcm, UINT count) {
+
+	SINT32	i;				//計算用
+	SINT64	i64;
+	UINT	cnt_ch;			//Slot用	カウンタ
+
+	SINT32	samp_l;
+	SINT32	samp_r;
+
+	UINT32	lfo_level;		//ハードウェアLFO
+	UINT8	lfo_shift;		//ハードウェアLFO
+
+	while(count>0){
+
+		samp_l = opngen.outdl * opngen.calcremain;
+		samp_r = opngen.outdr * opngen.calcremain;
+		opngen.calcremain = FMDIV_ENT - opngen.calcremain;
+
+		while(1){
+			opngen.playing = 0;
+			opngen.outdc = 0;
+			opngen.outdl = 0;
+			opngen.outdr = 0;
+
+			//Hardware LFO Frequency
+			if	(opngen.lfo_enable & 0x01){
+				i = opngen.lfo_freq_cnt + opngen.lfo_freq_inc;
+				opngen.lfo_freq_cnt = i;
+				i >>= (FREQ_BITS - SIN_BITS);
+				i &= (SIN_ENT - 1);
+				lfo_level = opncfg.sintable[i];
+				lfo_shift = opncfg.sinshift[i];
+			} else {
+				lfo_level = 0;
+				lfo_shift = 0;
+			}
+
+			//Each Channel process
+			for (cnt_ch=0; cnt_ch<opngen.playchannels; cnt_ch++) {
+				calcratechannel(&opnch[cnt_ch], lfo_level, lfo_shift);
+			}
+			if (opncfg.vr_en) {
+				SINT32 tmpl;
+				SINT32 tmpr;
+				tmpl = (opngen.outdl >> 5) * opncfg.vr_l;
+				tmpr = (opngen.outdr >> 5) * opncfg.vr_r;
+				opngen.outdl += tmpr;
+				opngen.outdr += tmpl;
+			}
+			opngen.outdl += opngen.outdc;
+			opngen.outdr += opngen.outdc;
+			opngen.outdl >>= FMVOL_SFTBIT;
+			opngen.outdr >>= FMVOL_SFTBIT;
+			if (opngen.calcremain > opncfg.calc1024) {
+				opngen.calcremain -= opncfg.calc1024;
+				samp_l += opngen.outdl * opncfg.calc1024;
+				samp_r += opngen.outdr * opncfg.calc1024;
+			} else {
+				break;
+			}
+		}
+		i64 = opngen.calcremain * opngen.outdl + samp_l;
+		i64 *= opncfg.fmvol;
+		pcm[0] += (SINT32)(i64 >> 32);
+
+		i64 = opngen.calcremain * opngen.outdr + samp_r;
+		i64 *= opncfg.fmvol;
+		pcm[1] += (SINT32)(i64 >> 32);
+
+		pcm += 2;
+
+		opngen.calcremain -= opncfg.calc1024;
+		count--;
+	}
+
+}
+

--- a/np2/sound/opngenc.c
+++ b/np2/sound/opngenc.c
@@ -18,10 +18,12 @@
 
 
 	OPNCFG	opncfg;
-#ifdef OPNGENX86
-	char	envshift[EVC_ENT];
-	char	sinshift[SIN_ENT];
-#endif
+
+//OPNCFG構造体のメンバー変数に、移動しました。
+//#ifdef OPNGENX86
+//	char	envshift[EVC_ENT];
+//	char	sinshift[SIN_ENT];
+//#endif
 
 
 static	SINT32	detunetable[8][32];
@@ -115,7 +117,7 @@ void opngen_initialize(UINT rate) {
 		while(sft < (ENVTBL_BIT + 8)) {
 			pom = (double)(1 << sft) / pow(10.0, EG_STEP*(EVC_ENT-i)/20.0);
 			opncfg.envtable[i] = (SINT32)pom;
-			envshift[i] = sft - TL_BITS;
+			opncfg.envshift[i] = sft - TL_BITS;
 			if (opncfg.envtable[i] >= (1 << (ENVTBL_BIT - 1))) {
 				break;
 			}
@@ -136,7 +138,7 @@ void opngen_initialize(UINT rate) {
 		while(sft < (SINTBL_BIT + 8)) {
 			pom = (double)(1 << sft) * sin(2*PI*i/SIN_ENT);
 			opncfg.sintable[i] = (SINT32)pom;
-			sinshift[i] = sft;
+			opncfg.sinshift[i] = sft;
 			if (opncfg.sintable[i] >= (1 << (SINTBL_BIT - 1))) {
 				break;
 			}

--- a/np2/sound/opngenc.c
+++ b/np2/sound/opngenc.c
@@ -49,9 +49,41 @@ static const UINT8 dttable[] = {
 static const int extendslot[4] = {2, 3, 1, 0};
 static const int fmslot[4] = {0, 2, 1, 3};
 
+//ハードウェアLFO関連のテーブル
+#if (EVC_BITS >= 7)
+#define	LA(n)	(SINT32)((n/0.75)*(1<<(EVC_BITS - 7)))/2
+#else
+#define	LA(n)	(SINT32)((n/0.75)*(1<<(7 - EVC_BITS)))/2
+#endif
+#define	LP(n)	(SINT32)
+       const double lfo_freq[8]			= {3.98, 5.56, 6.02, 6.37, 6.88, 9.63, 48.1, 72.2};	//単位 [Hz]
+       		 SINT32 lfo_freq_table[8]	= {0,0,0,0,0,0,0,0};
+	   const SINT32 lfo_pms_table[8]	= {
+				0x00000000/2,		// 0 [cent]
+				0x0080D56F/2,		// 3.4 [cent]	table = (1-(2^(n[cent]/1200))) * 2^32
+				0x00FE1ED5/2,		// 6.7 [cent]
+				0x017BA56C/2,		//10 [cent]
+				0x02141EA7/2,		//14 [cent]
+				0x02F97DDC/2,		//20 [cent]
+				0x05FBD4D5/2,		//40 [cent]
+				0x0C1B77B6/2};		//80 [cent]	MUL freq_inc,この値 を実行して、edxの数値を足す。
+       const SINT32 lfo_ams_table[4]	= {LA(0),LA(1.4),LA(5.9),LA(11.8)};	//[dB]
 
+
+//==============================================================
+//			ＯＰＮ処理関連の初期化
+//--------------------------------------------------------------
+//	◆引数
+//		UINT	rate	
+//	◆返り値
+//		無し
+//	◆備考
+//			
+//==============================================================
 void opngen_initialize(UINT rate) {
 
+	//------------------
+	//◆Local
 	UINT	ratebit;
 	int		i;
 	char	sft;
@@ -61,6 +93,8 @@ void opngen_initialize(UINT rate) {
 	double	freq;
 	UINT32	calcrate;
 
+	//------------------
+	//◆色々設定
 	if (rate == 44100) {
 		ratebit = 0;
 	}
@@ -73,6 +107,8 @@ void opngen_initialize(UINT rate) {
 	calcrate = (OPNA_CLOCK / 72) >> ratebit;
 	opncfg.calc1024 = FMDIV_ENT * 44100 / (OPNA_CLOCK / 72);
 
+	//------------------
+	//◆LOG Table
 	for (i=0; i<EVC_ENT; i++) {
 #ifdef OPNGENX86
 		sft = ENVTBL_BIT;
@@ -90,6 +126,9 @@ void opngen_initialize(UINT rate) {
 		opncfg.envtable[i] = (SINT32)pom;
 #endif
 	}
+
+	//------------------
+	//◆Sin wave Table
 	for (i=0; i<SIN_ENT; i++) {
 #ifdef OPNGENX86
 		char sft;
@@ -111,6 +150,9 @@ void opngen_initialize(UINT rate) {
 		opncfg.sintable[i] = (SINT32)pom;
 #endif
 	}
+
+	//------------------
+	//◆Envelope table
 	for (i=0; i<EVC_ENT; i++) {
 		pom = pow(((double)(EVC_ENT-1-i)/EVC_ENT), 8) * EVC_ENT;
 		opncfg.envcurve[i] = (SINT32)pom;
@@ -118,6 +160,8 @@ void opngen_initialize(UINT rate) {
 	}
 	opncfg.envcurve[EVC_ENT*2] = EVC_ENT;
 
+	//------------------
+	//◆
 //	opmbaserate = (1L << FREQ_BITS) / (rate * x / 44100) * 55466;
 //	でも今は x == 55466だから…
 
@@ -132,6 +176,8 @@ void opngen_initialize(UINT rate) {
 		opncfg.ratebit = 2 + (FREQ_BITS - 16);
 	}
 
+	//------------------
+	//◆Detune table
 	for (i=0; i<4; i++) {
 		for (j=0; j<32; j++) {
 			detune = dttable[i*32 + j];
@@ -147,6 +193,9 @@ void opngen_initialize(UINT rate) {
 			detunetable[i+4][j] = (SINT32)-detune;
 		}
 	}
+
+	//------------------
+	//◆Attack, Decay, Sustain Rate Table
 	for (i=0; i<4; i++) {
 		attacktable[i] = decaytable[i] = 0;
 	}
@@ -179,8 +228,17 @@ void opngen_initialize(UINT rate) {
 		attacktable[i] = attacktable[63];
 		decaytable[i] = decaytable[63];
 	}
+
+	//------------------
+	//◆ハードウェアLFOのfreq用テーブルの作成
+	for (i=0; i<8; i++) {
+		lfo_freq_table[i] = (SINT32)(((double)SIN_ENT / (((double)OPNA_CLOCK / 72) / lfo_freq[i] )) * (double)(1 << (opncfg.ratebit + 16 - SIN_BITS)));
+	}
 }
 
+//==============================================================
+//			
+//==============================================================
 void opngen_setvol(UINT vol) {
 
 	opncfg.fmvol = vol * 5 / 4;
@@ -189,6 +247,9 @@ void opngen_setvol(UINT vol) {
 #endif
 }
 
+//==============================================================
+//			
+//==============================================================
 void opngen_setVR(REG8 channel, REG8 value) {
 
 	if ((channel & 3) && (value)) {
@@ -201,15 +262,58 @@ void opngen_setVR(REG8 channel, REG8 value) {
 	}
 }
 
+//==============================================================
+//			エンベロープ形状の反映
+//--------------------------------------------------------------
+//	◆引数
+//			OPNSLOT *slot
+//	◆返り値
+//			無し
+//	◆備考
+//			エンベロープ関連のレジスタライト時は、
+//			発音中の音のエンベロープも更新する。
+//==============================================================
+void	Envlop_update(OPNSLOT *slot)
+{
+	SINT32	iRate;
 
-// ----
+	switch(slot->env_mode){
+		case(EM_ATTACK):	//AR中に相当
+			iRate = slot->env_inc_attack;
+			break;
+		case(EM_DECAY1):	//DR中に相当？
+		case(EM_DECAY2):	//SR中に相当？
+			if(slot->env_cnt < slot->decaylevel){
+				slot->env_mode	= EM_DECAY1;
+				slot->env_end	= slot->decaylevel;
+				iRate			= slot->env_inc_decay1;
+			} else {
+				slot->env_mode	= EM_DECAY2;
+				slot->env_end	= EC_OFF;
+				iRate			= slot->env_inc_decay2;
+			}
+			break;
+		case(EM_RELEASE):	//RR中に相当
+			iRate = slot->env_inc_release;
+			break;
+		default:			//EM_OFF
+			iRate = 0;
+			break;
+	}
+	slot->env_inc = iRate;		//ここで入れた方が、最適化してくれている。
+}
 
+//==============================================================
+//			OPN	AL
+//==============================================================
 static void set_algorithm(OPNCH *ch) {
 
-	SINT32	*outd;
+	SINT32	*outd;			//出力先
+	SINT32	*cn1;			
+	SINT32	*cn2;			
+	SINT32	*cn3;			//一旦、変数に入れたほうが、頭の良い機械語を生成するみたい。
 	UINT8	outslot;
 
-	outd = &opngen.outdc;
 	if (ch->stereo) {
 		switch(ch->pan & 0xc0) {
 			case 0x80:
@@ -219,75 +323,93 @@ static void set_algorithm(OPNCH *ch) {
 			case 0x40:
 				outd = &opngen.outdr;
 				break;
+			default:
+				outd = &opngen.outdc;
+				break;
 		}
+	} else {
+		outd = &opngen.outdc;
 	}
+
 	switch(ch->algorithm) {
-		case 0:
-			ch->connect1 = &opngen.feedback2;
-			ch->connect2 = &opngen.feedback3;
-			ch->connect3 = &opngen.feedback4;
+		case 0:		// [1] - [2] - [3] - [4]
+			cn1 = &opngen.feedback2;
+			cn2 = &opngen.feedback3;
+			cn3 = &opngen.feedback4;
 			outslot = 0x08;
 			break;
 
-		case 1:
-			ch->connect1 = &opngen.feedback3;
-			ch->connect2 = &opngen.feedback3;
-			ch->connect3 = &opngen.feedback4;
+		case 1:		// ([1] + [2]) - [3] - [4]
+			cn1 = &opngen.feedback3;
+			cn2 = &opngen.feedback3;
+			cn3 = &opngen.feedback4;
 			outslot = 0x08;
 			break;
 
-		case 2:
-			ch->connect1 = &opngen.feedback4;
-			ch->connect2 = &opngen.feedback3;
-			ch->connect3 = &opngen.feedback4;
+		case 2:		//	([1] + ([2] - [3])) - [4]
+			cn1 = &opngen.feedback4;
+			cn2 = &opngen.feedback3;
+			cn3 = &opngen.feedback4;
 			outslot = 0x08;
 			break;
 
-		case 3:
-			ch->connect1 = &opngen.feedback2;
-			ch->connect2 = &opngen.feedback4;
-			ch->connect3 = &opngen.feedback4;
+		case 3:		//	(([1] - [2]) + (3)] - [4]
+			cn1 = &opngen.feedback2;
+			cn2 = &opngen.feedback4;
+			cn3 = &opngen.feedback4;
 			outslot = 0x08;
 			break;
 
-		case 4:
-			ch->connect1 = &opngen.feedback2;
-			ch->connect2 = outd;
-			ch->connect3 = &opngen.feedback4;
+		case 4:		//	(([1] - [2]) + ([3] - [4]))
+			cn1 = &opngen.feedback2;
+			cn2 = outd;
+			cn3 = &opngen.feedback4;
 			outslot = 0x0a;
 			break;
 
-		case 5:
-			ch->connect1 = 0;
-			ch->connect2 = outd;
-			ch->connect3 = outd;
+		case 5:		//	[1] - ([2] + [3] + [4])
+			cn1 = 0;
+			cn2 = outd;
+			cn3 = outd;
 			outslot = 0x0e;
 			break;
 
-		case 6:
-			ch->connect1 = &opngen.feedback2;
-			ch->connect2 = outd;
-			ch->connect3 = outd;
+		case 6:		// ([1] - [2]) + [3] + [4]
+			cn1 = &opngen.feedback2;
+			cn2 = outd;
+			cn3 = outd;
 			outslot = 0x0e;
 			break;
 
-		case 7:
+		case 7:		//	[1] + [2] + [3] + [4]
 		default:
-			ch->connect1 = outd;
-			ch->connect2 = outd;
-			ch->connect3 = outd;
+			cn1 = outd;
+			cn2 = outd;
+			cn3 = outd;
 			outslot = 0x0f;
 	}
+
+	//ここで、一括で入れる。
+	//簡単なオペコードを生成させるする事で、プリフェッチのデコーダーへのスループットを上げる。
+	ch->connect1 = cn1;
+	ch->connect2 = cn2;
+	ch->connect3 = cn3;
 	ch->connect4 = outd;
 	ch->outslot = outslot;
 }
 
+//==============================================================
+//			OPN	DT & ML
+//==============================================================
 static void set_dt1_mul(OPNSLOT *slot, REG8 value) {
 
 	slot->multiple = (SINT32)multipletable[value & 0x0f];
 	slot->detune1 = detunetable[(value >> 4) & 7];
 }
 
+//==============================================================
+//			OPN	TL
+//==============================================================
 static void set_tl(OPNSLOT *slot, REG8 value) {
 
 #if (EVC_BITS >= 7)
@@ -297,6 +419,9 @@ static void set_tl(OPNSLOT *slot, REG8 value) {
 #endif
 }
 
+//==============================================================
+//			OPN KS & AL
+//==============================================================
 static void set_ks_ar(OPNSLOT *slot, REG8 value) {
 
 	slot->keyscale = ((~value) >> 6) & 3;
@@ -308,8 +433,12 @@ static void set_ks_ar(OPNSLOT *slot, REG8 value) {
 	}
 }
 
+//==============================================================
+//			OPN	DR
+//==============================================================
 static void set_d1r(OPNSLOT *slot, REG8 value) {
 
+	slot->amon = (value & 0x80) >> 7;
 	value &= 0x1f;
 	slot->decay1 = (value)?(decaytable + (value << 1)):nulltable;
 	slot->env_inc_decay1 = slot->decay1[slot->envratio];
@@ -318,37 +447,32 @@ static void set_d1r(OPNSLOT *slot, REG8 value) {
 	}
 }
 
+//==============================================================
+//			OPN	DT & SR
+//==============================================================
 static void set_dt2_d2r(OPNSLOT *slot, REG8 value) {
 
 	value &= 0x1f;
 	slot->decay2 = (value)?(decaytable + (value << 1)):nulltable;
-	if (slot->ssgeg1) {
-		slot->env_inc_decay2 = 0;
-	}
-	else {
-		slot->env_inc_decay2 = slot->decay2[slot->envratio];
-	}
+	slot->env_inc_decay2 = ((slot->ssgeg1==1)? 0 : slot->decay2[slot->envratio] );
 	if (slot->env_mode == EM_DECAY2) {
 		slot->env_inc = slot->env_inc_decay2;
 	}
 }
-
+//==============================================================
+//			OPN	DL & RR
+//==============================================================
 static void set_d1l_rr(OPNSLOT *slot, REG8 value) {
 
 	slot->decaylevel = decayleveltable[(value >> 4)];
 	slot->release = decaytable + ((value & 0x0f) << 2) + 2;
 	slot->env_inc_release = slot->release[slot->envratio];
-	if (slot->env_mode == EM_RELEASE) {
-		slot->env_inc = slot->env_inc_release;
-		if (value == 0xff) {
-			slot->env_mode = EM_OFF;
-			slot->env_cnt = EC_OFF;
-			slot->env_end = EC_OFF + 1;
-			slot->env_inc = 0;
-		}
-	}
+	Envlop_update(slot);	//SL, RRの変更なので、こっちで同時に更新する。
 }
 
+//==============================================================
+//			OPN SSGEG
+//==============================================================
 static void set_ssgeg(OPNSLOT *slot, REG8 value) {
 
 	value &= 0xf;
@@ -365,49 +489,43 @@ static void set_ssgeg(OPNSLOT *slot, REG8 value) {
 	}
 }
 
+//==============================================================
+//			KeyScaleと音程による、エンベロープ形状の更新
+//--------------------------------------------------------------
+//	◆引数
+//			OPNCH *ch
+//	◆返り値
+//			無し
+//	◆備考
+//			Key Scale等により、エンベロープ形状を更新する。
+//==============================================================
 static void channleupdate(OPNCH *ch) {
 
 	int		i;
-	UINT32	fc = ch->keynote[0];						// ver0.27
-	UINT8	kc = ch->kcode[0];
+	UINT8	kc;
 	UINT	evr;
-	OPNSLOT	*slot;
+	OPNSLOT	*slot = ch->slot;
 	int		s;
 
-	slot = ch->slot;
-	if (!(ch->extop)) {
-		for (i=0; i<4; i++, slot++) {
-			slot->freq_inc = (fc + slot->detune1[kc]) * slot->multiple;
-			evr = kc >> slot->keyscale;
-			if (slot->envratio != evr) {
-				slot->envratio = evr;
-				slot->env_inc_attack = slot->attack[evr];
-				slot->env_inc_decay1 = slot->decay1[evr];
-				slot->env_inc_decay2 = slot->decay2[evr];
-				slot->env_inc_release = slot->release[evr];
-			}
-		}
-	}
-	else {
-		for (i=0; i<4; i++, slot++) {
-			s = extendslot[i];
-			slot->freq_inc = (ch->keynote[s] + slot->detune1[ch->kcode[s]])
-														* slot->multiple;
-			evr = ch->kcode[s] >> slot->keyscale;
-			if (slot->envratio != evr) {
-				slot->envratio = evr;
-				slot->env_inc_attack = slot->attack[evr];
-				slot->env_inc_decay1 = slot->decay1[evr];
-				slot->env_inc_decay2 = slot->decay2[evr];
-				slot->env_inc_release = slot->release[evr];
-			}
+	for (i=0; i<4; i++, slot++) {
+		s = ((ch->extop)? extendslot[i] : 0);
+		kc = ch->kcode[s];
+		slot->freq_inc = (ch->keynote[s] + slot->detune1[kc]) * slot->multiple;
+		evr = kc >> slot->keyscale;
+		if (slot->envratio != evr) {
+			slot->envratio = evr;
+			slot->env_inc_attack = slot->attack[evr];
+			slot->env_inc_decay1 = slot->decay1[evr];
+			slot->env_inc_decay2 = ((slot->ssgeg1)? 0 : slot->decay2[evr] );
+			slot->env_inc_release = slot->release[evr];
+			Envlop_update(slot);	//更新があったら、エンベロープを更新
 		}
 	}
 }
 
-
-// ----
-
+//==============================================================
+//			
+//==============================================================
 void opngen_reset(void) {
 
 	OPNCH	*ch;
@@ -445,6 +563,9 @@ void opngen_reset(void) {
 	}
 }
 
+//==============================================================
+//			
+//==============================================================
 void opngen_setcfg(REG8 maxch, UINT32 flag) {
 
 	OPNCH	*ch;
@@ -472,6 +593,9 @@ void opngen_setcfg(REG8 maxch, UINT32 flag) {
 	}
 }
 
+//==============================================================
+//			
+//==============================================================
 void opngen_setextch(UINT chnum, REG8 data) {
 
 	OPNCH	*ch;
@@ -480,6 +604,18 @@ void opngen_setextch(UINT chnum, REG8 data) {
 	ch[chnum].extop = data;
 }
 
+//==============================================================
+//			レジスタライト
+//--------------------------------------------------------------
+//	◆引数
+//			REG8	chbase	
+//			UINT	reg		
+//			REG8	value	
+//	◆返り値
+//			
+//	◆備考
+//			
+//==============================================================
 void opngen_setreg(REG8 chbase, UINT reg, REG8 value) {
 
 	UINT	chpos;
@@ -487,6 +623,7 @@ void opngen_setreg(REG8 chbase, UINT reg, REG8 value) {
 	OPNSLOT	*slot;
 	UINT	fn;
 	UINT8	blk;
+	UINT	i;
 
 	chpos = reg & 3;
 	if (chpos == 3) {
@@ -494,7 +631,13 @@ void opngen_setreg(REG8 chbase, UINT reg, REG8 value) {
 	}
 	sound_sync();
 	ch = opnch + chbase + chpos;
-	if (reg < 0xa0) {
+	if (reg == 0x22) {					// LFO ON & Freq
+		if (ch->stereo) {
+			opngen.lfo_enable	= (value & 0x08) >> 3;
+			opngen.lfo_freq_inc	= lfo_freq_table[value & 0x07];
+			opngen.lfo_freq_cnt	= 0;
+		}
+	} else if (reg < 0xa0) {
 		slot = ch->slot + fmslot[(reg >> 2) & 3];
 		switch(reg & 0xf0) {
 			case 0x30:					// DT1 MUL
@@ -561,6 +704,24 @@ void opngen_setreg(REG8 chbase, UINT reg, REG8 value) {
 				break;
 
 			case 0xb0:
+				//エンベロープ初期化
+				slot = ch->slot;
+				for (i=0; i<4; i++) {
+					//発音中だったら、アタックからやり直す。
+					if(slot->env_mode > EM_RELEASE){
+						slot->env_mode = EM_ATTACK;
+						slot->env_cnt = EC_ATTACK;
+						slot->env_end = EC_DECAY;
+						slot->env_inc = slot->env_inc_attack;
+					//note off中だったら、発音なっしんぐ。
+					} else {
+						slot->env_mode = EM_OFF;
+						slot->env_cnt = EC_ATTACK;
+						slot->env_end = EC_DECAY;
+						slot->env_inc = 0;
+					}
+					slot++;
+				}
 				ch->algorithm = (UINT8)(value & 7);
 				value = (value >> 3) & 7;
 				if (value) {
@@ -573,19 +734,27 @@ void opngen_setreg(REG8 chbase, UINT reg, REG8 value) {
 				break;
 
 			case 0xb4:
-				ch->pan = (UINT8)(value & 0xc0);
+				if (ch->stereo) {
+					ch->pms = lfo_pms_table[ value & 0x07];	
+					ch->ams = lfo_ams_table[(value & 0x30) >> 4];
+					ch->pan = (UINT8)(value & 0xc0);
+				}
 				set_algorithm(ch);
 				break;
 		}
 	}
 }
 
+//==============================================================
+//			Key On
+//==============================================================
 void opngen_keyon(UINT chnum, REG8 value) {
 
 	OPNCH	*ch;
 	OPNSLOT	*slot;
 	REG8	bit;
 	UINT	i;
+	SINT32	iEnv;				//現在のエンベロープ値
 
 	sound_sync();
 	opngen.keyreg[chnum] = value;
@@ -601,16 +770,30 @@ void opngen_keyon(UINT chnum, REG8 value) {
 				if (i == OPNSLOT1) {
 					ch->op1fb = 0;
 				}
+				iEnv = opncfg.envcurve[slot->env_cnt >> ENV_BITS];	//現在の音量
 				slot->env_mode = EM_ATTACK;
 				slot->env_inc = slot->env_inc_attack;
-				slot->env_cnt = EC_ATTACK;
 				slot->env_end = EC_DECAY;
+				if (iEnv<=0) {
+					//アタックしきっている場合
+					slot->env_cnt  = EC_DECAY;
+				} else if (iEnv>=EVC_ENT) {
+					//減衰しきっている場合
+					slot->env_cnt  = EC_ATTACK;
+				} else {
+					//アタックは、現在のエンベロープの音量から始める。
+					slot->env_cnt = (long)((EVC_ENT-1 -sqrt(EVC_ENT*sqrt(EVC_ENT*sqrt(EVC_ENT*iEnv)))) * (1 << ENV_BITS));
+					if((slot->env_cnt)< EC_ATTACK ){
+						slot->env_cnt = EC_ATTACK;
+					}
+				}
 			}
 		}
 		else {										// keyoff
 			if (slot->env_mode > EM_RELEASE) {
 				slot->env_mode = EM_RELEASE;
 				if (!(slot->env_cnt & EC_DECAY)) {
+					//まだ、Decayに達していない場合。
 					slot->env_cnt = (opncfg.envcurve[slot->env_cnt
 										>> ENV_BITS] << ENV_BITS) + EC_DECAY;
 				}
@@ -624,6 +807,9 @@ void opngen_keyon(UINT chnum, REG8 value) {
 	keydisp_fmkeyon((UINT8)chnum, value);
 }
 
+//==============================================================
+//			
+//==============================================================
 void opngen_csm(void) {
 	opngen_keyon(2, 0x02);
 	opngen_keyon(2, 0xf2);

--- a/np2/sound/psggen.h
+++ b/np2/sound/psggen.h
@@ -23,7 +23,8 @@ typedef struct {
 typedef struct {
 	UINT32	freq;			/*!< frequency */
 	UINT32	count;			/*!< counter */
-	UINT	lfsr;			/*!< linear feedback shift register */
+//	UINT	lfsr;			/*!< linear feedback shift register */
+	UINT	base;
 } PSGNOISE;
 
 typedef struct {

--- a/np2/sound/psggenc.c
+++ b/np2/sound/psggenc.c
@@ -69,7 +69,7 @@ void psggen_reset(PSGGEN psg) {
 	for (i=0; i<3; i++) {
 		psg->tone[i].pvol = psggencfg.volume + 0;
 	}
-	psg->noise.lfsr = 1;
+//	psg->noise.lfsr = 1;
 	for (i=0; i<sizeof(psggen_deftbl); i++) {
 		psggen_setreg(psg, i, psggen_deftbl[i]);
 	}

--- a/np2/sound/psggeng.c
+++ b/np2/sound/psggeng.c
@@ -11,7 +11,7 @@ void SOUNDCALL psggen_getpcm(PSGGEN psg, SINT32 *pcm, UINT count) {
 
 	SINT32	noisevol;
 	UINT8	mixer;
-	UINT	noisetbl;
+	UINT	noisetbl = 0;
 	PSGTONE	*tone;
 	PSGTONE	*toneterm;
 	SINT32	samp;
@@ -53,14 +53,22 @@ void SOUNDCALL psggen_getpcm(PSGGEN psg, SINT32 *pcm, UINT count) {
 			}
 		}
 		mixer = psg->mixer;
-		noisetbl = 0;
+//		noisetbl = 0;
 		if (mixer & 0x38) {
 			for (i=0; i<(1 << PSGADDEDBIT); i++) {
-				if (psg->noise.count > psg->noise.freq) {
-					psg->noise.lfsr = (psg->noise.lfsr >> 1) ^ ((psg->noise.lfsr & 1) * 0x12000);
-				}
+	//			if (psg->noise.count > psg->noise.freq) {
+	//				psg->noise.lfsr = (psg->noise.lfsr >> 1) ^ ((psg->noise.lfsr & 1) * 0x12000);
+	//			}
+	//			psg->noise.count -= psg->noise.freq;
+	//			noisetbl |= (psg->noise.lfsr & 1) << i;
+				SINT32 countbak;
+				countbak = psg->noise.count;
 				psg->noise.count -= psg->noise.freq;
-				noisetbl |= (psg->noise.lfsr & 1) << i;
+				if (psg->noise.count > countbak) {
+					psg->noise.base = rand_get() & (1 << (1 << PSGADDEDBIT));
+				}
+				noisetbl += psg->noise.base;
+				noisetbl >>= 1;
 			}
 		}
 		tone = psg->tone;

--- a/np2/win9x/board118.cpp
+++ b/np2/win9x/board118.cpp
@@ -34,16 +34,18 @@ static void IOOUTCALL ymf_o18a(UINT port, REG8 dat) {
 	}
 	S98_put(NORMAL2608, addr, dat);
 	if (addr < 0x10) {
+		//0x00-0x0F: SSG
 		if (addr != 0x0e) {
 			psggen_setreg(&psg1, addr, dat);
 		}
 	}
 	else {
-		if (addr < 0x20) {
-			rhythm_setreg(&rhythm, addr, dat);
-		}
-		else if ((addr < 0x30) && (addr > 0x22)) {
-			if (addr == 0x28) {
+		if ((addr < 0x30) && (addr != 0x22)) {
+			if (addr < 0x20) {
+				//0x10-0x1F: Rhythm
+				rhythm_setreg(&rhythm, addr, dat);
+			} else if (addr == 0x28) {
+				//0x28: Key On/Off
 				if ((dat & 0x0f) < 3) {
 					opngen_keyon(dat & 0x0f, dat);
 				}
@@ -53,6 +55,7 @@ static void IOOUTCALL ymf_o18a(UINT port, REG8 dat) {
 				}
 			}
 			else {
+				//0x24-0x27: Timer
 				if (addr == 0x27) {
 					/* 118‚ÉCSMƒ‚[ƒh‚Í–³‚¢ */
 					dat &= ~0x80;
@@ -61,7 +64,8 @@ static void IOOUTCALL ymf_o18a(UINT port, REG8 dat) {
 				opnch[2].extop = dat & 0xc0;
 			}
 		}
-		else if (addr < 0xc0 || (addr == 0x22)) {
+		else if (addr < 0xc0) {
+			//0x22, 0x30-0xBF
 			opngen_setreg(0, addr, dat);
 		}
 		opn.reg[addr] = dat;

--- a/np2/win9x/np21vs2008.vcproj
+++ b/np2/win9x/np21vs2008.vcproj
@@ -106,88 +106,6 @@
 			/>
 		</Configuration>
 		<Configuration
-			Name="Debug|x64"
-			OutputDirectory="..\bin\$(SolutionName)\$(PlatformName)\$(ConfigurationName)"
-			IntermediateDirectory="..\obj\$(SolutionName)\$(PlatformName)\$(ConfigurationName)\$(ProjectName)"
-			ConfigurationType="1"
-			CharacterSet="1"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="NASM"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="YASM"
-				IncludePaths=".\x64;..\i386c\x64;..\io\x64"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-				TargetEnvironment="3"
-			/>
-			<Tool
-				Name="VCCLCompilerTool"
-				Optimization="0"
-				AdditionalIncludeDirectories=".\;.\x64;.\dialog;.\debuguty;..\;..\common;..\codecnv;..\i386c;..\i386c\ia32;..\i386c\ia32\instructions;..\i386c\ia32\instructions\fpu;..\mem;..\io;..\cbus;..\bios;..\lio;..\vram;..\sound;..\sound\vermouth;..\sound\getsnd;..\fdd;..\font;..\generic;..\trap;..\zlib"
-				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_DEPRECATE;SUPPORT_PC9821"
-				MinimalRebuild="true"
-				BasicRuntimeChecks="3"
-				RuntimeLibrary="1"
-				UsePrecompiledHeader="0"
-				WarningLevel="3"
-				DebugInformationFormat="3"
-			/>
-			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-				PreprocessorDefinitions="_WIN64;_UNICODE;UNICODE;SUPPORT_PC9821"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
-			<Tool
-				Name="VCLinkerTool"
-				LinkIncremental="2"
-				GenerateDebugInformation="true"
-				SubSystem="2"
-				LargeAddressAware="1"
-				TargetMachine="17"
-			/>
-			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-			/>
-		</Configuration>
-		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="..\bin\$(SolutionName)\$(PlatformName)\$(ConfigurationName)"
 			IntermediateDirectory="..\obj\$(SolutionName)\$(PlatformName)\$(ConfigurationName)\$(ProjectName)"
@@ -247,6 +165,88 @@
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
 				TargetMachine="1"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
+		<Configuration
+			Name="Debug|x64"
+			OutputDirectory="..\bin\$(SolutionName)\$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="..\obj\$(SolutionName)\$(PlatformName)\$(ConfigurationName)\$(ProjectName)"
+			ConfigurationType="1"
+			CharacterSet="1"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="NASM"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="YASM"
+				IncludePaths=".\x64;..\i386c\x64;..\io\x64"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				TargetEnvironment="3"
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="0"
+				AdditionalIncludeDirectories=".\;.\x64;.\dialog;.\debuguty;..\;..\common;..\codecnv;..\i386c;..\i386c\ia32;..\i386c\ia32\instructions;..\i386c\ia32\instructions\fpu;..\mem;..\io;..\cbus;..\bios;..\lio;..\vram;..\sound;..\sound\vermouth;..\sound\getsnd;..\fdd;..\font;..\generic;..\trap;..\zlib"
+				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_DEPRECATE;SUPPORT_PC9821"
+				MinimalRebuild="true"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="1"
+				UsePrecompiledHeader="0"
+				WarningLevel="3"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+				PreprocessorDefinitions="_WIN64;_UNICODE;UNICODE;SUPPORT_PC9821"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				LinkIncremental="2"
+				GenerateDebugInformation="true"
+				SubSystem="2"
+				LargeAddressAware="1"
+				TargetMachine="17"
 			/>
 			<Tool
 				Name="VCALinkTool"
@@ -579,7 +579,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Debug|x64"
+						Name="Release|Win32"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -587,7 +587,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Release|Win32"
+						Name="Debug|x64"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -1096,6 +1096,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\sound\opngen86.cpp"
+					>
+				</File>
+				<File
 					RelativePath="..\sound\opngenc.c"
 					>
 				</File>
@@ -1239,7 +1243,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Debug|x64"
+						Name="Release|Win32"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -1247,7 +1251,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Release|Win32"
+						Name="Debug|x64"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -1621,6 +1625,14 @@
 					<File
 						RelativePath=".\x86\opngeng.x86"
 						>
+						<FileConfiguration
+							Name="Release|Win32"
+							ExcludedFromBuild="true"
+							>
+							<Tool
+								Name="NASM"
+							/>
+						</FileConfiguration>
 						<FileConfiguration
 							Name="Debug|x64"
 							ExcludedFromBuild="true"

--- a/np2/win9x/np2vs2008.vcproj
+++ b/np2/win9x/np2vs2008.vcproj
@@ -105,6 +105,92 @@
 			/>
 		</Configuration>
 		<Configuration
+			Name="Release|Win32"
+			OutputDirectory="..\bin\$(SolutionName)\$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="..\obj\$(SolutionName)\$(PlatformName)\$(ConfigurationName)\$(ProjectName)"
+			ConfigurationType="1"
+			CharacterSet="1"
+			WholeProgramOptimization="1"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="NASM"
+				IncludePaths=".\x86\;..\i286x\;..\io\x86\"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="YASM"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="2"
+				EnableIntrinsicFunctions="true"
+				FavorSizeOrSpeed="1"
+				OmitFramePointers="true"
+				AdditionalIncludeDirectories=".\;.\x86;.\dialog;.\debuguty;..\;..\common;..\codecnv;..\i286x;..\mem;..\io;..\cbus;..\bios;..\lio;..\vram;..\sound;..\sound\vermouth;..\sound\getsnd;..\fdd;..\font;..\generic;..\trap;..\zlib"
+				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS"
+				StringPooling="true"
+				RuntimeLibrary="0"
+				EnableFunctionLevelLinking="true"
+				UsePrecompiledHeader="0"
+				AssemblerOutput="4"
+				WarningLevel="3"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				LinkIncremental="1"
+				GenerateDebugInformation="false"
+				SubSystem="2"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				TargetMachine="1"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
+		<Configuration
 			Name="Debug|x64"
 			OutputDirectory="..\bin\$(SolutionName)\$(PlatformName)\$(ConfigurationName)"
 			IntermediateDirectory="..\obj\$(SolutionName)\$(PlatformName)\$(ConfigurationName)\$(ProjectName)"
@@ -163,88 +249,6 @@
 				SubSystem="2"
 				LargeAddressAware="1"
 				TargetMachine="17"
-			/>
-			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-			/>
-		</Configuration>
-		<Configuration
-			Name="Release|Win32"
-			OutputDirectory="..\bin\$(SolutionName)\$(PlatformName)\$(ConfigurationName)"
-			IntermediateDirectory="..\obj\$(SolutionName)\$(PlatformName)\$(ConfigurationName)\$(ProjectName)"
-			ConfigurationType="1"
-			CharacterSet="1"
-			WholeProgramOptimization="1"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="NASM"
-				IncludePaths=".\x86\;..\i286x\;..\io\x86\"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="YASM"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
-			<Tool
-				Name="VCCLCompilerTool"
-				Optimization="2"
-				EnableIntrinsicFunctions="true"
-				AdditionalIncludeDirectories=".\;.\x86;.\dialog;.\debuguty;..\;..\common;..\codecnv;..\i286x;..\mem;..\io;..\cbus;..\bios;..\lio;..\vram;..\sound;..\sound\vermouth;..\sound\getsnd;..\fdd;..\font;..\generic;..\trap;..\zlib"
-				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS"
-				RuntimeLibrary="0"
-				EnableFunctionLevelLinking="true"
-				UsePrecompiledHeader="0"
-				WarningLevel="3"
-				DebugInformationFormat="3"
-			/>
-			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
-			<Tool
-				Name="VCLinkerTool"
-				LinkIncremental="1"
-				GenerateDebugInformation="true"
-				SubSystem="2"
-				OptimizeReferences="2"
-				EnableCOMDATFolding="2"
-				TargetMachine="1"
 			/>
 			<Tool
 				Name="VCALinkTool"
@@ -605,7 +609,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Debug|x64"
+						Name="Release|Win32"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -613,7 +617,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Release|Win32"
+						Name="Debug|x64"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -1502,6 +1506,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\sound\opngen86.cpp"
+					>
+				</File>
+				<File
 					RelativePath="..\sound\opngenc.c"
 					>
 				</File>
@@ -1661,7 +1669,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Debug|x64"
+						Name="Release|Win32"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -1669,7 +1677,7 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
-						Name="Release|Win32"
+						Name="Debug|x64"
 						ExcludedFromBuild="true"
 						>
 						<Tool
@@ -2087,6 +2095,14 @@
 					<File
 						RelativePath=".\x86\opngeng.x86"
 						>
+						<FileConfiguration
+							Name="Release|Win32"
+							ExcludedFromBuild="true"
+							>
+							<Tool
+								Name="NASM"
+							/>
+						</FileConfiguration>
 						<FileConfiguration
 							Name="Debug|x64"
 							ExcludedFromBuild="true"

--- a/np2/win9x/x86/opngeng.x86
+++ b/np2/win9x/x86/opngeng.x86
@@ -50,6 +50,7 @@ EM_OFF			equ		0
 .env_inc_decay1	resd	1		; 3c
 .env_inc_decay2	resd	1		; 40
 .env_inc_rel	resd	1		; 44
+.amon			resd	1		; 48
 				endstruc
 
 				struc	ch_t
@@ -71,6 +72,8 @@ EM_OFF			equ		0
 .extop			resb	1
 .stereo			resb	1
 				resb	1
+.pms			resd	1
+.ams			resd	1
 				endstruc
 
 				struc opngen_t
@@ -83,6 +86,9 @@ EM_OFF			equ		0
 .outdc			resd	1
 .outdr			resd	1
 .calcremain		resd	1
+.lfo_freq_cnt		resd	1	; frequency count
+.lfo_freq_inc		resd	1	; frequency step
+.lfo_enable		resd	1
 .keyreg			resb	12
 				endstruc
 


### PR DESCRIPTION
お世話になります。
過去、自分がやっていたFM音源のエミュレートを実ハードに合わせる改造の一部を適用してみました。詳細な変更は、以下４点になります。

- AR, FBレジスタに書き込みし、且つ、発音中の音がReleaseフェーズ以外のフェーズであった場合、発音中のエンベロープのポインタをリセットするようにした。

- KSレジスタに書き込みし、且つ、発音中の音があった場合、発音中の音のエンベロープのRateもKSに応じて更新するようにした。

- DLレジスタに書き込みし、且つ、発音中の音がDecayフェーズで減衰が既にDecayLevelに達していた場合、発音中の音をSustainフェーズに移行するようにした。

- KeyOnした場時に前の音が残っている（エンベロープが減衰しきっていない、又はAttackフェーズであった）場合、現時点のレベルからアタックするようにした。


ご確認いただければと思います。

ＰＳ．
また、ハードウェアＬＦＯの実装の準備をとして、ＦＭ音源関連の構造体に、メンバー変数を追加しています。
LFOの処理部は、当時、Visual C++ 2008 に付属していたMacro assembler で書いていたので、こちらはまだですが・・・（NASMの文法を覚えるか、C言語で書き直すか、悩み中です）
